### PR TITLE
Pipeline fixes, minimal FFmpeg build configuration for audio-only workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,12 @@
 name: Build
 
 on:
-
   workflow_dispatch:
-
   push:
-
   pull_request:
-
-
-
 
 permissions:
   contents: write  #publish release
-
 
 jobs:
 
@@ -21,9 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ Release ]
+        build_type: ["Release"]
     runs-on: windows-latest
-    name: "x86_64 win ${{ matrix.config }}"
+    name: "x86_64 win ${{ matrix.build_type }}"
     steps:
       - name: Install Dependencies
         run: |
@@ -35,7 +28,7 @@ jobs:
           conan install conanfile.txt --build=missing -r conancenter --deployer full_deploy --output-folder out -s arch=x86_64
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: ffmpeg-x86_64-win-${{ matrix.config }}
+          name: ffmpeg-x86_64-win-${{ matrix.build_type }}
           path: out/**/*.*
           if-no-files-found: error
 
@@ -43,9 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ Release ]
+        build_type: ["Release"]
     runs-on: ubuntu-latest
-    name: "x86_64 linux ${{ matrix.config }}"
+    name: "x86_64 linux ${{ matrix.build_type }}"
     steps:
       - name: Install Dependencies
         run: |
@@ -57,7 +50,7 @@ jobs:
           conan install conanfile.txt --build=missing -r conancenter --deployer full_deploy --output-folder out -s arch=x86_64 -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: ffmpeg-x86_64-linux-${{ matrix.config }}
+          name: ffmpeg-x86_64-linux-${{ matrix.build_type }}
           path: out/**/*.*
           if-no-files-found: error
 
@@ -65,13 +58,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ Release ]
+        build_type: [ "Release" ]
     runs-on: macos-latest
-    name: "x86_64 macos ${{ matrix.config }}"
+    name: "x86_64 macos ${{ matrix.build_type }}"
     steps:
       - name: Install Dependencies
         run: |
-          brew install cmake conan
+          brew install --overwrite python@3.12 cmake conan
       - uses: actions/checkout@v3
       - name: Run on architecture
         run: |
@@ -79,7 +72,7 @@ jobs:
           conan install conanfile.txt --build=missing -r conancenter --deployer full_deploy --output-folder out -s arch=x86_64
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: ffmpeg-x86_64-macos-${{ matrix.config }}
+          name: ffmpeg-x86_64-macos-${{ matrix.build_type }}
           path: out/**/*.*
           if-no-files-found: error
 
@@ -87,13 +80,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ Release ]
+        build_type: [ "Release" ]
     runs-on: macos-13-xl
-    name: "aarch64 macos ${{ matrix.config }}"
+    name: "aarch64 macos ${{ matrix.build_type }}"
     steps:
       - name: Install Dependencies
         run: |
-          brew install cmake conan
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          brew install --force --overwrite python@3.12 cmake conan
       - uses: actions/checkout@v3
       - name: Run on architecture
         run: |
@@ -101,7 +95,7 @@ jobs:
           conan install conanfile.txt --build=missing -r conancenter --deployer full_deploy --output-folder out -s arch=armv8
       - uses: actions/upload-artifact@v3.1.2
         with:
-          name: ffmpeg-aarch64-macos-${{ matrix.config }}
+          name: ffmpeg-aarch64-macos-${{ matrix.build_type }}
           path: out/**/*.*
           if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Dependencies
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
-          brew install --force --overwrite python@3.12 cmake conan
+          brew install --force --overwrite python@3.11 python@3.12 cmake conan
       - uses: actions/checkout@v3
       - name: Run on architecture
         run: |

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -6,30 +6,55 @@ CMakeToolchain
 [layout]
 cmake_layout
 [options]
+# Build settings
 ffmpeg/*:shared=True
-ffmpeg/*:avcodec=True
-ffmpeg/*:swscale=True
-ffmpeg/*:avdevice=True
-ffmpeg/*:avfilter=True
-ffmpeg/*:avformat=True
-ffmpeg/*:postproc=False
+
+# Toggleable dependencies
 ffmpeg/*:with_asm=True
-ffmpeg/*:with_sdl=False
-ffmpeg/*:with_ssl=False
 ffmpeg/*:with_lzma=True
-ffmpeg/*:with_opus=False
-ffmpeg/*:with_zlib=False
-ffmpeg/*:swresample=True
 ffmpeg/*:with_bzip2=False
-ffmpeg/*:with_libvpx=False
+ffmpeg/*:with_zlib=False
+ffmpeg/*:with_freetype=False
+ffmpeg/*:with_openjpeg=False
+ffmpeg/*:with_openh264=False
+ffmpeg/*:with_opus=True
 ffmpeg/*:with_vorbis=True
-ffmpeg/*:with_zeromq=False
-ffmpeg/*:with_libwebp=False
 ffmpeg/*:with_libx264=False
 ffmpeg/*:with_libx265=False
-ffmpeg/*:with_freetype=False
-ffmpeg/*:with_libiconv=False
-ffmpeg/*:with_openh264=False
-ffmpeg/*:with_openjpeg=False
-ffmpeg/*:with_libfdk_aac=False
+ffmpeg/*:with_libvpx=False
+ffmpeg/*:with_libsvtav1=False
 ffmpeg/*:with_libmp3lame=True
+ffmpeg/*:with_libfdk_aac=True
+ffmpeg/*:with_libdav1d=False
+ffmpeg/*:with_libaom=False
+ffmpeg/*:with_libwebp=False
+ffmpeg/*:with_ssl=False
+ffmpeg/*:with_libalsa=False
+ffmpeg/*:with_pulse=False
+ffmpeg/*:with_vaapi=False
+ffmpeg/*:with_vdpau=False
+ffmpeg/*:with_xcb=False
+ffmpeg/*:with_appkit=False
+ffmpeg/*:with_avfoundation=False
+ffmpeg/*:with_audiotoolbox=False
+ffmpeg/*:with_videotoolbox=False
+ffmpeg/*:with_coreimage=False
+
+# Minimal FFmpeg build settings,
+# basically including only audio formats
+# with non-problematic licenses.
+# We purposefully try to avoid system libraries like MediaFoundation
+ffmpeg/*:avdevice=False
+ffmpeg/*:postproc=False
+ffmpeg/*:swresample=True
+ffmpeg/*:swscale=False
+
+ffmpeg/*:disable_everything=True
+ffmpeg/*:disable_all_hardware_accelerators=True
+ffmpeg/*:enable_demuxers=image2,aac,ac3,aiff,ape,asf,au,avi,flac,flv,matroska,mov,m4v,mp3,mpc*,ogg,pcm*,rm,shorten,tak,tta,wav,wv,xwma,dsf,dts,truehd
+ffmpeg/*:enable_muxers=image2,ac3,aiff,asf,au,avi,flac,flv,matroska,mov,m4v,mp3*,ogg,pcm*,rm,tta,wav,wv,dts,truehd
+ffmpeg/*:enable_decoders=aac,ac3,als,atrac*,eac3,flac,gsm*,mp1*,mp2*,mp3float,mp3,mpc*,opus,ra*,ralf,shorten,tak,tta,libvorbis,wavpack,wma*,pcm*,dsd*,truehd,mjpeg
+ffmpeg/*:enable_encoders=aac,ac3,eac3,flac,mp2*,libmp3lame,opus,ra*,tta,libvorbis,wavpack,wma*,pcm*,truehd,mjpeg
+ffmpeg/*:enable_parsers=aac*,ac3,cook,dca,flac,gsm,mpegaudio,tak,vorbis
+ffmpeg/*:enable_filters=aresample
+ffmpeg/*:enable_protocols=file


### PR DESCRIPTION
Minimal FFmpeg build with a handful audio codecs, minimal audio filters, no devices, no video codecs, no protocols besides local file reading.