### PR TITLE
Set required libs as shared

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,6 +8,13 @@ cmake_layout
 [options]
 # Build settings
 ffmpeg/*:shared=True
+libfdk_aac/*:shared=True
+libiconv/*:shared=True
+libmp3lame/*:shared=True
+ogg/*:shared=True
+opus/*:shared=True
+vorbis/*:shared=True
+xz_utils/*:shared=True
 
 # Toggleable dependencies
 ffmpeg/*:with_asm=True


### PR DESCRIPTION
Some of the required libraries for the build were built as static libs - this makes them shared libs.

Relates to https://github.com/YoYoGames/GameMaker-Bugs/issues/2592.